### PR TITLE
Add support for old go versions.

### DIFF
--- a/gethostname.go
+++ b/gethostname.go
@@ -22,4 +22,4 @@ func stripPost(u *url.URL) string {
 		return strings.TrimPrefix(hostport[:i], "[")
 	}
 	return hostport[:colon]
-
+}

--- a/gethostname.go
+++ b/gethostname.go
@@ -1,0 +1,25 @@
+// +build go1.5, go1.6, go1.7, !go1.8
+
+package main
+
+import (
+	"net/url"
+	"strings"
+)
+
+// this is workaround  block for go < 1.8
+func getHostname(u *url.URL) string {
+	return stripPost(u)
+}
+
+func stripPost(u *url.URL) string {
+	hostport := u.Host
+	colon := strings.IndexByte(hostport, ':')
+	if colon == -1 {
+		return hostport
+	}
+	if i := strings.IndexByte(hostport, ']'); i != -1 {
+		return strings.TrimPrefix(hostport[:i], "[")
+	}
+	return hostport[:colon]
+

--- a/gethostname_18.go
+++ b/gethostname_18.go
@@ -1,0 +1,12 @@
+// +build go1.8
+
+package main
+
+import (
+	"net/url"
+)
+
+// this is workaround  block for go < 1.8
+func getHostname(u *url.URL) string {
+	return u.Hostname()
+}

--- a/proxy.go
+++ b/proxy.go
@@ -13,7 +13,8 @@ import (
 var rutrackerHostsRE = regexp.MustCompile(`^bt[2-5]?\.(rutracker\.org|t-ru\.org|rutracker\.cc)$`)
 
 func proxyHandler(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-	if rutrackerHostsRE.MatchString(req.URL.Hostname()) {
+	hostname := getHostname(req.URL)
+	if rutrackerHostsRE.MatchString(hostname) {
 		log.Printf("Querying to %s through proxy...", req.URL)
 		resp, err := ctx.RoundTrip(req)
 		if err != nil {


### PR DESCRIPTION
Данный патч позволяет собирать rutracker-proxy с версиями go меньше 1.8.